### PR TITLE
Feature/add two qubit params experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+- Add TwoQubitExperimentNodeParameters class
+
 ## [0.1.0] - 2025-05-07
 ### Added
 - First release for the Superconducting QUAlibration graph.

--- a/qualibration_libs/parameters/__init__.py
+++ b/qualibration_libs/parameters/__init__.py
@@ -1,5 +1,5 @@
 from .common import CommonNodeParameters
-from .experiment import QubitsExperimentNodeParameters, TwoQubitExperimentNodeParameters, get_qubits
+from .experiment import QubitsExperimentNodeParameters, TwoQubitExperimentNodeParameters, get_qubits, get_qubit_pairs
 from .sweep import IdleTimeNodeParameters, get_idle_times_in_clock_cycles
 
 __all__ = [
@@ -7,6 +7,7 @@ __all__ = [
     "QubitsExperimentNodeParameters",
     "TwoQubitExperimentNodeParameters",
     "get_qubits",
+    "get_qubit_pairs",
     "IdleTimeNodeParameters",
     "get_idle_times_in_clock_cycles",
 ]

--- a/qualibration_libs/parameters/__init__.py
+++ b/qualibration_libs/parameters/__init__.py
@@ -1,10 +1,11 @@
 from .common import CommonNodeParameters
-from .experiment import QubitsExperimentNodeParameters, get_qubits
+from .experiment import QubitsExperimentNodeParameters, TwoQubitExperimentNodeParameters, get_qubits
 from .sweep import IdleTimeNodeParameters, get_idle_times_in_clock_cycles
 
 __all__ = [
     "CommonNodeParameters",
     "QubitsExperimentNodeParameters",
+    "TwoQubitExperimentNodeParameters",
     "get_qubits",
     "IdleTimeNodeParameters",
     "get_idle_times_in_clock_cycles",

--- a/qualibration_libs/parameters/experiment.py
+++ b/qualibration_libs/parameters/experiment.py
@@ -5,6 +5,7 @@ from qualibrate.parameters import RunnableParameters
 from qualibration_libs.core import BatchableList
 from quam_builder.architecture.superconducting.qpu import AnyQuam
 from quam_builder.architecture.superconducting.qubit import AnyTransmon
+from quam_builder.architecture.superconducting.qubit_pair import AnyTransmonPair
 
 
 class BaseExperimentNodeParameters(RunnableParameters):
@@ -49,6 +50,28 @@ def _get_qubits(machine: AnyQuam, node_parameters: QubitsExperimentNodeParameter
         qubits = [machine.qubits[q] for q in node_parameters.qubits]
 
     return qubits
+
+
+def get_qubit_pairs(node: QualibrationNode) -> BatchableList[AnyTransmonPair]:
+    qubit_pairs = _get_qubit_pairs(node.machine, node.parameters)
+
+    if isinstance(node.parameters, TwoQubitExperimentNodeParameters):
+        multiplexed = node.parameters.multiplexed
+    else:
+        multiplexed = False
+
+    qubit_pairs_batchable_list = _make_batchable_list_from_multiplexed(qubit_pairs, multiplexed)
+
+    return qubit_pairs_batchable_list
+
+
+def _get_qubit_pairs(machine: AnyQuam, node_parameters: TwoQubitExperimentNodeParameters) -> List[AnyTransmonPair]:
+    if node_parameters.qubit_pairs is None or node_parameters.qubit_pairs == "":
+        qubit_pairs = machine.active_qubit_pairs
+    else:
+        qubit_pairs = [machine.qubit_pairs[q] for q in node_parameters.qubit_pairs]
+
+    return qubit_pairs
 
 
 def _make_batchable_list_from_multiplexed(items: List, multiplexed: bool) -> BatchableList:

--- a/qualibration_libs/parameters/experiment.py
+++ b/qualibration_libs/parameters/experiment.py
@@ -19,6 +19,19 @@ class QubitsExperimentNodeParameters(RunnableParameters):
     """The qubit reset method to use. Must be implemented as a method of Quam.qubit. Can be "thermal", "active", or
     "active_gef". Default is "thermal"."""
 
+class TwoQubitExperimentNodeParameters(RunnableParameters):
+    qubit_pairs: Optional[List[str]] = None
+    """A list of qubit names which should participate in the execution of the node. Default is None."""
+    multiplexed: bool = False
+    """Whether to play control pulses, readout pulses and active/thermal reset at the same time for all qubits (True)
+    or to play the experiment sequentially for each qubit (False). Default is False."""
+    use_state_discrimination: bool = False
+    """Whether to use on-the-fly state discrimination and return the qubit 'state', or simply return the demodulated
+    quadratures 'I' and 'Q'. Default is False."""
+    reset_type: Literal["thermal", "active", "active_gef"] = "thermal"
+    """The qubit reset method to use. Must be implemented as a method of Quam.qubit. Can be "thermal", "active", or
+    "active_gef". Default is "thermal"."""
+
 
 def get_qubits(node: QualibrationNode) -> BatchableList[AnyTransmon]:
     qubits = _get_qubits(node.machine, node.parameters)


### PR DESCRIPTION
Added classes/functions to be used in 2 qubit protocols.
These are corresponding classes/functions used for 1 qubit protocols.

Please advise which ticket I should refer to:
https://quantum-machines.atlassian.net/browse/PRD-844