### PR TITLE
Feature/add two qubit params experiments iqcc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+- Add TwoQubitExperimentNodeParameters class
+
 ## [0.1.0] - 2025-05-07
 ### Added
 - First release for the Superconducting QUAlibration graph.

--- a/qualibration_libs/data/__init__.py
+++ b/qualibration_libs/data/__init__.py
@@ -1,7 +1,9 @@
 from .fetcher import XarrayDataFetcher
 from .processing import *
+from .cloud_processing import CloudDataProcessor
 
 __all__ = [
     *fetcher.__all__,
     *processing.__all__,
+    *cloud_processing.__all__,
 ]

--- a/qualibration_libs/data/cloud_processing.py
+++ b/qualibration_libs/data/cloud_processing.py
@@ -1,0 +1,108 @@
+import numpy as np
+import xarray as xr
+from typing import Dict, Tuple, Union, Literal, Optional, List
+
+
+__all__ = ["CloudDataProcessor"]
+
+
+class CloudDataProcessor:
+    def __init__(
+        self,
+        data_dict: dict,
+        sweep_axes: Dict[str, xr.DataArray],
+        outer_key: Literal["qubit", "qubit_pair"],
+        fetch_names: Union[str, List[str]],
+    ):
+        """
+        Class to convert cloud IQCC API results into an xarray.Dataset.
+
+        Args:
+            data_dict: Raw data dictionary from the IQCC cloud API.
+            sweep_axes: Axes metadata as xr.DataArray.
+            outer_key: Name of the outer axis ("qubit" or "qubit_pair").
+            state_discrimination: Expect "state" instead of I/Q.
+            adc_trace: Expect ADC trace data.
+        """
+        self.data_dict = dict(data_dict)
+        self.sweep_axes = sweep_axes
+        self.outer_key = outer_key
+        self.fetch_names = fetch_names
+
+        for key, da in self.sweep_axes.items():
+            if da.dims and da.dims[0] != key:
+                da = da.rename({da.dims[0]: key})
+            self.sweep_axes[key] = da
+
+    def _prepare_data_dict(self) -> dict:
+        axis_values = self.sweep_axes[self.outer_key].data
+        
+        return {
+            (qb_qp, fetch_name): np.array(self.data_dict[f"{fetch_name}{i + 1}"])
+            for i, qb_qp in enumerate(axis_values)
+            for fetch_name in self.fetch_names
+        }
+
+    def _init_data_vars(self, var_names: list, shape: Tuple[int, ...]) -> Dict[str, np.ndarray]:
+        """Initialize data arrays filled with NaNs."""
+        return {name: np.full(shape, np.nan, dtype=np.float64) for name in var_names}
+
+    def _insert_array(
+        self,
+        data_array: np.ndarray,
+        key: Union[str, Tuple],
+        array: Optional[np.ndarray],
+        outer_labels: np.ndarray,
+        all_axes: list,
+        outer_axis: str,
+    ):
+        """Insert one array into the right slice of a full array."""
+        if array is None:
+            return
+
+        coord_dict = self.sweep_axes
+        coord_sizes = {k: v.size for k, v in coord_dict.items()}
+        inner_axes = [ax for ax in all_axes if ax != outer_axis]
+        expected_shape = tuple(coord_sizes[ax] for ax in inner_axes)
+
+        if array.shape != expected_shape:
+            raise ValueError(f"Shape mismatch for {key}: expected {expected_shape}, got {array.shape}")
+
+        slices = [slice(None)] * len(all_axes)
+        slices[0] = outer_labels.tolist().index(key)
+        data_array[tuple(slices)] = array
+
+    def _build_full_data(self, all_axes: list, shape: Tuple[int, ...]) -> Dict[str, np.ndarray]:
+        """Build the full data variables dictionary based on the prepared data."""
+        outer_labels = self.sweep_axes[self.outer_key].values
+        full_data = self._init_data_vars(self.fetch_names, shape)
+
+        for q in outer_labels:
+            for fetch_name in self.fetch_names:
+                self._insert_array(
+                    full_data[fetch_name],
+                    q,
+                    self._prepared_data.get((q, fetch_name)),
+                    outer_labels,
+                    all_axes,
+                    self.outer_key,
+                )
+
+        return full_data
+
+    def build_dataset(self) -> xr.Dataset:
+        """Build and return an xarray.Dataset based on the initialized parameters."""
+
+        self._prepared_data = self._prepare_data_dict()
+        coord_dict = dict(self.sweep_axes)
+        all_axes = list(coord_dict.keys())
+        coord_sizes = {k: v.size for k, v in coord_dict.items()}
+        full_shape = [coord_sizes[ax] for ax in all_axes]
+
+        full_data = self._build_full_data(all_axes, tuple(full_shape))
+
+        self._dataset = xr.Dataset(
+            data_vars={k: (all_axes, v) for k, v in full_data.items()},
+            coords=coord_dict,
+        )
+        return self._dataset

--- a/qualibration_libs/data/fetcher.py
+++ b/qualibration_libs/data/fetcher.py
@@ -187,6 +187,10 @@ class XarrayDataFetcher:
         axes_shape = tuple(self.axes[dim].size for dim in dims_order)
         logger.debug(f"Axes shape: {axes_shape}")
 
+        # safe guard for non_qubit_shape of _update_qubit_data_arrays
+        if dims_order[0] not in ["qubit", "qubit_pair"]:
+            logger.error("first axis must be either qubit or qubit_pair")
+
         # Determine reference shape from non-None entries.
         data_arrays = [d for d in raw_data_arrays.values() if isinstance(d, np.ndarray)]
         if data_arrays:
@@ -304,7 +308,7 @@ class XarrayDataFetcher:
         for key, data in raw_data.items():
             if not isinstance(data, (np.ndarray, type(None))):
                 continue
-            m = re.match(r"([a-zA-Z_]+)(\d+)$", key)
+            m = re.match(r"([a-zA-Z_]+?(?:_(c|t)+)?)(\d+)$", key)
             if m:
                 base = m.group(1)
                 idx = int(m.group(2))

--- a/qualibration_libs/parameters/__init__.py
+++ b/qualibration_libs/parameters/__init__.py
@@ -1,5 +1,5 @@
 from .common import CommonNodeParameters
-from .experiment import QubitsExperimentNodeParameters, TwoQubitExperimentNodeParameters, get_qubits
+from .experiment import QubitsExperimentNodeParameters, TwoQubitExperimentNodeParameters, get_qubits, get_qubit_pairs
 from .sweep import IdleTimeNodeParameters, get_idle_times_in_clock_cycles
 
 __all__ = [
@@ -7,6 +7,7 @@ __all__ = [
     "QubitsExperimentNodeParameters",
     "TwoQubitExperimentNodeParameters",
     "get_qubits",
+    "get_qubit_pairs",
     "IdleTimeNodeParameters",
     "get_idle_times_in_clock_cycles",
 ]

--- a/qualibration_libs/parameters/__init__.py
+++ b/qualibration_libs/parameters/__init__.py
@@ -1,10 +1,11 @@
 from .common import CommonNodeParameters
-from .experiment import QubitsExperimentNodeParameters, get_qubits
+from .experiment import QubitsExperimentNodeParameters, TwoQubitExperimentNodeParameters, get_qubits
 from .sweep import IdleTimeNodeParameters, get_idle_times_in_clock_cycles
 
 __all__ = [
     "CommonNodeParameters",
     "QubitsExperimentNodeParameters",
+    "TwoQubitExperimentNodeParameters",
     "get_qubits",
     "IdleTimeNodeParameters",
     "get_idle_times_in_clock_cycles",

--- a/qualibration_libs/parameters/experiment.py
+++ b/qualibration_libs/parameters/experiment.py
@@ -5,6 +5,7 @@ from qualibrate.parameters import RunnableParameters
 from qualibration_libs.core import BatchableList
 from quam_builder.architecture.superconducting.qpu import AnyQuam
 from quam_builder.architecture.superconducting.qubit import AnyTransmon
+from quam_builder.architecture.superconducting.qubit_pair import AnyTransmonPair
 
 
 class BaseExperimentNodeParameters(RunnableParameters):
@@ -49,6 +50,28 @@ def _get_qubits(machine: AnyQuam, node_parameters: QubitsExperimentNodeParameter
         qubits = [machine.qubits[q] for q in node_parameters.qubits]
 
     return qubits
+
+
+def get_qubit_pairs(node: QualibrationNode) -> BatchableList[AnyTransmonPair]:
+    qubit_pairs = _get_qubit_pairs(node.machine, node.parameters)
+
+    if isinstance(node.parameters, TwoQubitExperimentNodeParameters):
+        multiplexed = node.parameters.multiplexed
+    else:
+        multiplexed = False
+
+    qubit_pairs_batchable_list = _make_batchable_list_from_multiplexed(qubit_pairs, multiplexed)
+
+    return qubit_pairs_batchable_list
+
+
+def _get_qubit_pairs(machine: AnyQuam, node_parameters: TwoQubitExperimentNodeParameters) -> List[AnyTransmonPair]:
+    if node_parameters.qubit_pairs is None or node_parameters.qubit_pairs == "":
+        qubit_pairs = machine.active_qubit_pairs
+    else:
+        qubit_pairs = [machine.qubit_pairs[q] for q in node_parameters.qubit_pairs]
+
+    return qubit_pairs
 
 
 def _make_batchable_list_from_multiplexed(items: List, multiplexed: bool) -> BatchableList:

--- a/qualibration_libs/parameters/experiment.py
+++ b/qualibration_libs/parameters/experiment.py
@@ -19,6 +19,19 @@ class QubitsExperimentNodeParameters(RunnableParameters):
     """The qubit reset method to use. Must be implemented as a method of Quam.qubit. Can be "thermal", "active", or
     "active_gef". Default is "thermal"."""
 
+class TwoQubitExperimentNodeParameters(RunnableParameters):
+    qubit_pairs: Optional[List[str]] = None
+    """A list of qubit names which should participate in the execution of the node. Default is None."""
+    multiplexed: bool = False
+    """Whether to play control pulses, readout pulses and active/thermal reset at the same time for all qubits (True)
+    or to play the experiment sequentially for each qubit (False). Default is False."""
+    use_state_discrimination: bool = False
+    """Whether to use on-the-fly state discrimination and return the qubit 'state', or simply return the demodulated
+    quadratures 'I' and 'Q'. Default is False."""
+    reset_type: Literal["thermal", "active", "active_gef"] = "thermal"
+    """The qubit reset method to use. Must be implemented as a method of Quam.qubit. Can be "thermal", "active", or
+    "active_gef". Default is "thermal"."""
+
 
 def get_qubits(node: QualibrationNode) -> BatchableList[AnyTransmon]:
     qubits = _get_qubits(node.machine, node.parameters)


### PR DESCRIPTION
This branches branched from
- [feature/add-two-qubit-params-experiments](https://github.com/qua-platform/qualibration-libs/tree/feature/add-two-qubit-params-experiments) <- not merged to `main` yet
    - <- [feature/add-two-qubit-params](https://github.com/qua-platform/qualibration-libs/tree/feature/add-two-qubit-params) <- not merged to `main` yet


The modifications include:
- added class and functions:
    - TwoQubitExperimentNodeParameters: parameter class for 2-qubit experiments
    - get_qubit_pairs: get qubit_pairs for the run

- added & updated
    - convert_IQ_to_V to work for both `qubits` and `qubit_pairs`
    - features for fetching both `qubits` and `qubit_pairs` under `update_dataset` of `XarrayDataFetcher`

- added class for processing IQCC cloud data
    - objective: convert IQCC cloud data to `Xarray` to provide the same interface to `calibration_utils/{analysis.py|plotting.py}`
    - class: CloudDataProcessor
