### PR TITLE
Bump version v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+## [0.1.1] - 2025-08-06
 ### Changed
 - Transfer the `power_tools` to quam-builder to remove its dependency to qualibration-libs.
 
@@ -11,5 +13,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - First release for the Superconducting QUAlibration graph.
 
-[Unreleased]: https://github.com/qua-platform/qualibration-libs/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/qua-platform/qualibration-libs/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/qua-platform/qualibration-libs/releases/tag/v0.1.1
 [0.1.0]: https://github.com/qua-platform/qualibration-libs/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.1.1] - 2025-08-06
+## [0.2.0] - 2025-08-06
 ### Changed
 - Transfer the `power_tools` to quam-builder to remove its dependency to qualibration-libs.
 
@@ -13,6 +13,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - First release for the Superconducting QUAlibration graph.
 
-[Unreleased]: https://github.com/qua-platform/qualibration-libs/compare/v0.1.1...HEAD
-[0.1.1]: https://github.com/qua-platform/qualibration-libs/releases/tag/v0.1.1
+[Unreleased]: https://github.com/qua-platform/qualibration-libs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/qua-platform/qualibration-libs/releases/tag/v0.2.0
 [0.1.0]: https://github.com/qua-platform/qualibration-libs/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualibration-libs"
-version = "0.1.1"
+version = "0.2.0"
 description = "Utility library supporting calibration nodes and graphs for the QUAlibration graphs platform."
 readme = "README.md"
 authors = [{ name = "Theo Laudat", email = "theo@quantum-machines.co" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qualibration-libs"
-version = "0.1.0"
+version = "0.1.1"
 description = "Utility library supporting calibration nodes and graphs for the QUAlibration graphs platform."
 readme = "README.md"
 authors = [{ name = "Theo Laudat", email = "theo@quantum-machines.co" }]


### PR DESCRIPTION
### Changed
- Transfer the `power_tools` to quam-builder to remove its dependency to qualibration-libs.
